### PR TITLE
Update squeeze.py

### DIFF
--- a/pandas_ta/momentum/squeeze.py
+++ b/pandas_ta/momentum/squeeze.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from numpy import NaN as npNaN
+from numpy import nan as npNaN
 from pandas import DataFrame
 from pandas_ta.momentum import mom
 from pandas_ta.overlap import ema, linreg, sma


### PR DESCRIPTION
fix: change element NaN in "from numpy import NaN as npNaN" to "from numpy import nan as npNaN" due ImportError: cannot import name 'NaN' from 'numpy', which changed "nan"